### PR TITLE
Introduced new escaped identifier token

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -13,6 +13,7 @@ pub enum Token {
     Operator(OperatorToken),
     Punctuation(PunctuationToken),
     Keyword(KeywordToken),
+    EscapedIdentifier(EscapedIdentifierToken),
     Error(ErrorToken),
     EOF(FilePosition),
 }
@@ -58,6 +59,12 @@ pub struct PunctuationToken {
 #[derive(Debug, PartialEq, Eq)]
 pub struct KeywordToken {
     keyword: Keyword,
+    position: FilePosition,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct EscapedIdentifierToken {
+    identifier: String,
     position: FilePosition,
 }
 
@@ -108,6 +115,15 @@ impl BuildToken<Punctuation> for PunctuationToken {
         Token::Punctuation(PunctuationToken {
             punctuation,
             position,
+        })
+    }
+}
+
+impl BuildToken<String> for EscapedIdentifierToken {
+    fn build_token(identifier: String, position: FilePosition) -> Token {
+        Token::EscapedIdentifier(EscapedIdentifierToken {
+            identifier,
+            position
         })
     }
 }


### PR DESCRIPTION
## What?
Introduced a new escaped identifier token to remove the coupling of character sequences and escaped identifiers.
## Why?
The original tokens used to implement the lexer were insufficient to cover all the tokens found within the file. For more information, see #10 
## How?
To resolve this, a new `EscapedIdentifierToken` was introduced, and a separate lexical operation, `EscapeIdentifier,` was added to allow the lexer to lex character sequences and escaped identifiers separately.
## Testing?
Character sequence token tests were amended to no longer check for escaped identifiers and added two test cases that verify the new `EscapedIdentifierToken` is lexed correctly.
## Anything Else?
resolves #10.
