### PR TITLE
Naive simple identifier parsing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: 
-      - "*"
+    branches: [ "*" ]
   pull_request:
-    branches: 
-      - "main"
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,11 @@ name: Rust
 
 on:
   push:
-    branches: [ "*" ]
+    branches: 
+      - "*"
   pull_request:
-    branches: [ "main" ]
+    branches: 
+      - "main"
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -525,11 +525,11 @@ mod tests {
     }
 
     fn assert_tokens_equal(tokens: TokenStream, expected_tokens: Vec<Token>) {
-        let token_iterator = tokens.iter().enumerate();
+        let token_iterator = tokens.enumerate();
         let mut length = 0;
 
         for (i, token) in token_iterator {
-            assert_eq!(token, &expected_tokens[i]);
+            assert_eq!(token, expected_tokens[i]);
             length += 1;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,5 @@ pub mod punctuation;
 pub mod keywords;
 pub mod token;
 pub mod token_stream;
+pub mod parser;
+pub mod syntax_node;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,47 @@
+use crate::{syntax_node::{SyntaxNode, IdentifierNode}, token_stream::TokenStream, lexer::FilePosition};
+
+pub struct Parser {
+    token_stream: TokenStream,
+    errors: Vec<String>,
+}
+
+impl Parser {
+    pub fn new(token_stream: TokenStream) -> Parser {
+        Parser {
+            token_stream,
+            errors: vec![],
+        }
+    }
+
+    pub fn parse(&mut self) -> Result<Option<SyntaxNode>, Vec<String>> {
+        Ok(Some(IdentifierNode::new(String::from("abc"), FilePosition::new(1,1))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        lexer::FilePosition,
+        syntax_node::IdentifierNode,
+        token::{BuildToken, CharacterSequenceToken},
+        token_stream::TokenStream,
+    };
+
+    use super::Parser;
+
+    #[test]
+    fn should_parse_simple_identifier() -> Result<(), Vec<String>> {
+        let expected_ast = IdentifierNode::new(String::from("abc"), FilePosition::new(1, 1));
+        let tokens = TokenStream::new(vec![CharacterSequenceToken::build_token(
+            String::from("abc"),
+            FilePosition::new(0, 0),
+        )]);
+        let mut parser = Parser::new(tokens);
+
+        let ast = parser.parse()?.unwrap();
+
+        assert_eq!(ast, expected_ast);
+
+        Ok(())
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::{
     syntax_node::{IdentifierNode, SyntaxNode},
-    token:: Token,
+    token::Token,
     token_stream::TokenStream,
 };
 
@@ -27,7 +27,7 @@ impl Parser {
     }
 
     fn parse_simple_identifier(&mut self) -> Option<SyntaxNode> {
-        if let Token::CharacterSequence(token) = self.next_token().unwrap() {
+        if let Some(Token::CharacterSequence(token)) = self.next_token() {
             let (identifier, position) = token.consume();
             return Some(IdentifierNode::new(identifier, position));
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,37 +1,174 @@
+use std::iter::Peekable;
+
 use crate::{
+    lexer::FilePosition,
+    punctuation::Punctuation,
     syntax_node::{IdentifierNode, SyntaxNode},
-    token::Token,
+    token::{Consume, Token},
     token_stream::TokenStream,
 };
 
 pub struct Parser {
-    token_stream: TokenStream,
+    token_stream: Peekable<TokenStream>,
+    errors: Vec<String>,
 }
 
 impl Parser {
     pub fn new(token_stream: TokenStream) -> Parser {
-        Parser { token_stream }
+        Parser {
+            token_stream: token_stream.peekable(),
+            errors: Vec::new(),
+        }
     }
 
-    pub fn parse(&mut self) -> Option<SyntaxNode> {
-        let simple_identifier = self.parse_simple_identifier();
+    pub fn parse(&mut self) -> Result<SyntaxNode, &Vec<String>> {
+        let mut root: Option<SyntaxNode> = None;
+
+        match self.parse_simple_identifier() {
+            Err(message) => self.errors.push(message),
+            Ok(token) => root = Some(token),
+        }
 
         match self.next_token() {
-            Some(Token::EOF(_)) => simple_identifier,
-            _ => None,
+            Some(Token::EOF(_)) => (),
+            _ => self.errors.push(String::from("Expected eof")),
+        };
+
+        if !self.errors.is_empty() {
+            return Err(&self.errors);
         }
+
+        return Ok(root.unwrap());
     }
 
     fn next_token(&mut self) -> Option<Token> {
         self.token_stream.next()
     }
 
-    fn parse_simple_identifier(&mut self) -> Option<SyntaxNode> {
-        if let Some(Token::CharacterSequence(token)) = self.next_token() {
-            let (identifier, position) = token.consume();
-            return Some(IdentifierNode::new(identifier, position));
+    fn peek_token(&mut self) -> Option<&Token> {
+        self.token_stream.peek()
+    }
+
+    fn is_next_token_character_sequence(&mut self) -> bool {
+        match self.peek_token() {
+            Some(Token::CharacterSequence(_)) => true,
+            _ => false,
+        }
+    }
+
+    fn is_next_token_number(&mut self) -> bool {
+        match self.peek_token() {
+            Some(Token::Number(_)) => true,
+            _ => false,
+        }
+    }
+
+    fn is_next_token_punctuation(&mut self, punctuation: Punctuation) -> bool {
+        match self.peek_token() {
+            Some(Token::Punctuation(token)) => token.punctuation() == &punctuation,
+            _ => false,
+        }
+    }
+
+    fn parse_simple_identifier(&mut self) -> Result<SyntaxNode, String> {
+        let mut identifier = Vec::new();
+        let position: Option<FilePosition>;
+
+        if self.can_read_simple_identifier_beginning_token() {
+            let (character_sequence, file_position) = self.consume_next_token_as_string().unwrap();
+
+            position = Some(file_position);
+            identifier.push(character_sequence);
+        } else {
+            return Err(String::from(
+                "Identifier must start with _ or character sequence",
+            ));
         }
 
-        None
+        while self.can_read_simple_identifier_token() {
+            if let Some((part, _)) = self.consume_next_token_as_string() {
+                identifier.push(part);
+            }
+        }
+
+        Ok(IdentifierNode::new(identifier.join(""), position.unwrap()))
+    }
+
+    fn can_read_simple_identifier_beginning_token(&mut self) -> bool {
+        self.is_next_token_character_sequence()
+            || self.is_next_token_punctuation(Punctuation::Underscore)
+    }
+
+    fn can_read_simple_identifier_token(&mut self) -> bool {
+        self.is_next_token_character_sequence()
+            || self.is_next_token_number()
+            || self.is_next_token_punctuation(Punctuation::Dollar)
+            || self.is_next_token_punctuation(Punctuation::Underscore)
+    }
+
+    fn consume_next_token_as_string(&mut self) -> Option<(String, FilePosition)> {
+        match self.next_token() {
+            Some(Token::CharacterSequence(token)) => Some(token.consume()),
+            Some(Token::Number(token)) => Some(token.consume()),
+            Some(Token::Punctuation(token)) => {
+                let (punctuation, position) = token.consume();
+                Some((Parser::parse_punctuation(punctuation), position))
+            }
+            _ => None,
+        }
+    }
+
+    fn parse_punctuation(punctuation: Punctuation) -> String {
+        String::from(match punctuation {
+            Punctuation::Dollar => "$",
+            Punctuation::Pound => "#",
+            Punctuation::Colon => ":",
+            Punctuation::Comma => ",",
+            Punctuation::Period => ".",
+            Punctuation::Asperand => "@",
+            Punctuation::Backtick => "`",
+            Punctuation::LeftBrace => "{",
+            Punctuation::BackSlash => "\\",
+            Punctuation::Semicolon => ";",
+            Punctuation::RightBrace => "}",
+            Punctuation::Apostrophe => "'",
+            Punctuation::Underscore => "_",
+            Punctuation::LeftBracket => "[",
+            Punctuation::RightBracket => "]",
+            Punctuation::QuestionMark => "?",
+            Punctuation::LeftParentheses => "(",
+            Punctuation::RightParentheses => ")",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        lexer::FilePosition,
+        punctuation::Punctuation,
+        syntax_node::IdentifierNode,
+        token::{BuildToken, CharacterSequenceToken, NumberToken, PunctuationToken},
+        token_stream::TokenStream,
+    };
+
+    use super::Parser;
+
+    #[test]
+    fn should_parse_identifier() {
+        let expected_node = IdentifierNode::new(String::from("abc123$_"), FilePosition::new(1, 1));
+        let tokens = vec![
+            CharacterSequenceToken::build_token(String::from("abc"), FilePosition::new(1, 1)),
+            NumberToken::build_token(String::from("123"), FilePosition::new(1, 1)),
+            PunctuationToken::build_token(Punctuation::Dollar, FilePosition::new(1, 1)),
+            PunctuationToken::build_token(Punctuation::Underscore, FilePosition::new(1, 1)),
+        ];
+        let mut parser = Parser::new(TokenStream::new(tokens));
+
+        let node = parser
+            .parse_simple_identifier()
+            .expect("Should not be none");
+
+        assert_eq!(node, expected_node);
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -35,32 +35,3 @@ impl Parser {
         None
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::{
-        lexer::FilePosition,
-        syntax_node::IdentifierNode,
-        token::{BuildToken, CharacterSequenceToken, Token},
-        token_stream::TokenStream,
-    };
-
-    use super::Parser;
-
-    #[test]
-    fn should_parse_simple_identifier() {
-        let identifier = String::from("abc");
-        let position = FilePosition::new(1, 1);
-        let expected_ast = IdentifierNode::new(identifier, position);
-        let tokens = TokenStream::new(vec![
-            CharacterSequenceToken::build_token(String::from("abc"), FilePosition::new(1, 1)),
-            Token::EOF(FilePosition::new(1, 4)),
-        ]);
-        let mut parser = Parser::new(tokens);
-
-        let ast = parser.parse().unwrap();
-
-        assert_eq!(ast, expected_ast);
-        assert!(parser.token_stream.next().is_none());
-    }
-}

--- a/src/syntax_node.rs
+++ b/src/syntax_node.rs
@@ -1,18 +1,18 @@
 use crate::lexer::FilePosition;
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum SyntaxNode {
-    Identifier(IdentifierNode),
+pub enum SyntaxNode<'a> {
+    Identifier(IdentifierNode<'a>),
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct IdentifierNode {
-    identifier: String,
-    position: FilePosition,
+pub struct IdentifierNode<'a> {
+    identifier: &'a String,
+    position: &'a FilePosition,
 }
 
-impl IdentifierNode {
-    pub fn new(identifier: String, position: FilePosition) -> SyntaxNode {
+impl<'a> IdentifierNode<'a> {
+    pub fn new<'b>(identifier: &'b String, position: &'b FilePosition) -> SyntaxNode<'b> {
         SyntaxNode::Identifier(IdentifierNode {
             identifier,
             position,

--- a/src/syntax_node.rs
+++ b/src/syntax_node.rs
@@ -1,18 +1,18 @@
 use crate::lexer::FilePosition;
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum SyntaxNode<'a> {
-    Identifier(IdentifierNode<'a>),
+pub enum SyntaxNode {
+    Identifier(IdentifierNode),
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct IdentifierNode<'a> {
-    identifier: &'a String,
-    position: &'a FilePosition,
+pub struct IdentifierNode {
+    identifier: String,
+    position: FilePosition,
 }
 
-impl<'a> IdentifierNode<'a> {
-    pub fn new<'b>(identifier: &'b String, position: &'b FilePosition) -> SyntaxNode<'b> {
+impl IdentifierNode {
+    pub fn new(identifier: String, position: FilePosition) -> SyntaxNode {
         SyntaxNode::Identifier(IdentifierNode {
             identifier,
             position,

--- a/src/syntax_node.rs
+++ b/src/syntax_node.rs
@@ -1,0 +1,21 @@
+use crate::lexer::FilePosition;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SyntaxNode {
+    Identifier(IdentifierNode),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct IdentifierNode {
+    identifier: String,
+    position: FilePosition,
+}
+
+impl IdentifierNode {
+    pub fn new(identifier: String, position: FilePosition) -> SyntaxNode {
+        SyntaxNode::Identifier(IdentifierNode {
+            identifier,
+            position,
+        })
+    }
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -26,10 +26,24 @@ pub trait BuildToken<T> {
     fn build_token(value: T, position: FilePosition) -> Token;
 }
 
+pub trait Consume {
+    type Item;
+
+    fn consume(self) -> (Self::Item, FilePosition);
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct NumberToken {
     number: String,
     position: FilePosition,
+}
+
+impl Consume for NumberToken {
+    type Item = String;
+
+    fn consume(self) -> (Self::Item, FilePosition) {
+        return (self.number, self.position);
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -44,8 +58,10 @@ pub struct CharacterSequenceToken {
     position: FilePosition,
 }
 
-impl CharacterSequenceToken {
-    pub fn consume(self) -> (String, FilePosition) {
+impl Consume for CharacterSequenceToken {
+    type Item = String;
+
+    fn consume(self) -> (Self::Item, FilePosition) {
         return (self.character_sequence, self.position);
     }
 }
@@ -60,6 +76,20 @@ pub struct OperatorToken {
 pub struct PunctuationToken {
     punctuation: Punctuation,
     position: FilePosition,
+}
+
+impl PunctuationToken {
+    pub fn punctuation(&self) -> &Punctuation {
+        &self.punctuation
+    }
+}
+
+impl Consume for PunctuationToken {
+    type Item = Punctuation;
+
+    fn consume(self) -> (Self::Item, FilePosition) {
+        return (self.punctuation, self.position)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -129,7 +159,7 @@ impl BuildToken<String> for EscapedIdentifierToken {
     fn build_token(identifier: String, position: FilePosition) -> Token {
         Token::EscapedIdentifier(EscapedIdentifierToken {
             identifier,
-            position
+            position,
         })
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -44,6 +44,16 @@ pub struct CharacterSequenceToken {
     position: FilePosition,
 }
 
+impl CharacterSequenceToken {
+    pub fn character_sequence(&self) -> &String {
+        return &self.character_sequence;
+    }
+
+    pub fn position(&self) -> &FilePosition {
+        return &self.position;
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct OperatorToken {
     operator: Operator,

--- a/src/token.rs
+++ b/src/token.rs
@@ -45,12 +45,8 @@ pub struct CharacterSequenceToken {
 }
 
 impl CharacterSequenceToken {
-    pub fn character_sequence(&self) -> &String {
-        return &self.character_sequence;
-    }
-
-    pub fn position(&self) -> &FilePosition {
-        return &self.position;
+    pub fn consume(self) -> (String, FilePosition) {
+        return (self.character_sequence, self.position);
     }
 }
 

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -1,45 +1,57 @@
+use std::collections::VecDeque;
+
 use crate::token::Token;
 
 #[derive(Debug)]
 pub struct TokenStream {
-    tokens: Vec<Token>,
+    tokens: VecDeque<Token>,
 }
 
 impl TokenStream {
     pub fn new(tokens: Vec<Token>) -> TokenStream {
         TokenStream {
-            tokens,
+            tokens: VecDeque::from(tokens),
         }
     }
+}
 
-    pub fn iter(&self) -> impl Iterator<Item = &Token> + '_ {
-        self.tokens.iter()
+impl Iterator for TokenStream {
+    type Item = Token;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.tokens.pop_front()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::token::{NumberToken, BuildToken, StringLiteralToken, CharacterSequenceToken, Token};
     use crate::lexer::FilePosition;
+    use crate::token::{
+        BuildToken, CharacterSequenceToken, NumberToken, StringLiteralToken, Token,
+    };
 
     use super::TokenStream;
 
     #[test]
     fn should_iterate_over_token_stream() {
-        let tokens = vec![
+        let expected_tokens = vec![
             NumberToken::build_token(String::from("123"), FilePosition::new(1, 1)),
             StringLiteralToken::build_token(String::from("foo"), FilePosition::new(1, 1)),
             CharacterSequenceToken::build_token(String::from("abc"), FilePosition::new(1, 1)),
-            Token::EOF(FilePosition::new(1,1))
+            Token::EOF(FilePosition::new(1, 1)),
         ];
-        
-        let token_stream = TokenStream::new(tokens);
-        let mut x = token_stream.iter();
 
-        assert_eq!(x.next().unwrap(), &token_stream.tokens[0]);
-        assert_eq!(x.next().unwrap(), &token_stream.tokens[1]);
-        assert_eq!(x.next().unwrap(), &token_stream.tokens[2]);
-        assert_eq!(x.next().unwrap(), &token_stream.tokens[3]);
-        assert!(x.next().is_none());
+        let mut token_stream = TokenStream::new(vec![
+            NumberToken::build_token(String::from("123"), FilePosition::new(1, 1)),
+            StringLiteralToken::build_token(String::from("foo"), FilePosition::new(1, 1)),
+            CharacterSequenceToken::build_token(String::from("abc"), FilePosition::new(1, 1)),
+            Token::EOF(FilePosition::new(1, 1)),
+        ]);
+
+        assert_eq!(token_stream.next().unwrap(), expected_tokens[0]);
+        assert_eq!(token_stream.next().unwrap(), expected_tokens[1]);
+        assert_eq!(token_stream.next().unwrap(), expected_tokens[2]);
+        assert_eq!(token_stream.next().unwrap(), expected_tokens[3]);
+        assert!(token_stream.next().is_none());
     }
 }

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -98,8 +98,8 @@ fn should_lex_svaunit_seq() {
 
     let tokens = lexer.lex();
 
-    for (i, token) in tokens.iter().enumerate() {
-        assert_eq!(token, &expected_tokens[i]);
+    for (i, token) in tokens.enumerate() {
+        assert_eq!(token, expected_tokens[i]);
     }
 }
 
@@ -1643,7 +1643,7 @@ fn should_lex_data_table() {
 
     let tokens = lexer.lex();
 
-    for (i, token) in tokens.iter().enumerate() {
-        assert_eq!(token, &expected_tokens[i]);
+    for (i, token) in tokens.enumerate() {
+        assert_eq!(token, expected_tokens[i]);
     }
 }


### PR DESCRIPTION
## Summary
Simple identifier parsing assumes that all the tokens in the input stream are valid and follow the BNF form for a simple identifier. 

## Testing
The naive implementation is tested via a unit test in the module.