### PR TITLE
Introduce token struct

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -60,7 +60,7 @@ pub struct Lexer {
     mark: Option<Mark>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct FilePosition {
     column: u64,
     row: u64,
@@ -532,7 +532,7 @@ mod tests {
         let mut length = 0;
 
         for (i, token) in token_iterator {
-            assert_eq!(token, expected_tokens[i]);
+            assert_eq!(token.kind(), &expected_tokens[i]);
             length += 1;
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,7 +77,7 @@ impl Parser {
 
     fn file_position(&mut self) -> Result<FilePosition, ParseError> {
         if let Some(token) = self.peek_token() {
-            return Ok(token.file_position());
+            return Ok(token.position());
         }
 
         Err(ParseError::new("", FilePosition::new(0, 0)))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,7 +77,7 @@ impl Parser {
 
     fn file_position(&mut self) -> Result<FilePosition, ParseError> {
         if let Some(token) = self.peek_token() {
-            return Ok(token.position());
+            return Ok(token.file_position());
         }
 
         Err(ParseError::new("", FilePosition::new(0, 0)))

--- a/src/token.rs
+++ b/src/token.rs
@@ -18,6 +18,29 @@ pub enum Token {
     EOF(FilePosition),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct TokenStruct {
+    kind: Token,
+}
+
+impl TokenStruct {
+    pub fn new(kind: Token) -> TokenStruct {
+        TokenStruct { kind }
+    }
+
+    pub fn position(&self) -> FilePosition {
+        self.kind.file_position().clone()
+    }
+
+    pub fn kind(&self) -> &Token {
+        &self.kind
+    }
+
+    pub fn consume(self) -> Token {
+        self.kind
+    }
+}
+
 impl Token {
     pub fn file_position(&self) -> FilePosition {
         match self {

--- a/src/token.rs
+++ b/src/token.rs
@@ -5,8 +5,8 @@ use crate::punctuation::Punctuation;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Token {
-    WhiteSpace,
-    Comment,
+    WhiteSpace(FilePosition),
+    Comment(FilePosition),
     Number(NumberToken),
     StringLiteral(StringLiteralToken),
     CharacterSequence(CharacterSequenceToken),
@@ -16,6 +16,24 @@ pub enum Token {
     EscapedIdentifier(EscapedIdentifierToken),
     Error(ErrorToken),
     EOF(FilePosition),
+}
+
+impl Token {
+    pub fn file_position(&self) -> FilePosition {
+        match self {
+            Token::Comment(position) | Token::WhiteSpace(position) | Token::EOF(position) => {
+                position.clone()
+            }
+            Token::Number(token) => token.position.clone(),
+            Token::StringLiteral(token) => token.position.clone(),
+            Token::CharacterSequence(token) => token.position.clone(),
+            Token::Operator(token) => token.position.clone(),
+            Token::Punctuation(token) => token.position.clone(),
+            Token::Keyword(token) => token.position.clone(),
+            Token::EscapedIdentifier(token) => token.position.clone(),
+            Token::Error(token) => token.position.clone(),
+        }
+    }
 }
 
 pub trait TokenFromSequence {
@@ -29,7 +47,7 @@ pub trait BuildToken<T> {
 pub trait Consume {
     type Item;
 
-    fn consume(self) -> (Self::Item, FilePosition);
+    fn consume(self) -> Self::Item;
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -41,8 +59,8 @@ pub struct NumberToken {
 impl Consume for NumberToken {
     type Item = String;
 
-    fn consume(self) -> (Self::Item, FilePosition) {
-        return (self.number, self.position);
+    fn consume(self) -> Self::Item {
+        return self.number;
     }
 }
 
@@ -61,8 +79,8 @@ pub struct CharacterSequenceToken {
 impl Consume for CharacterSequenceToken {
     type Item = String;
 
-    fn consume(self) -> (Self::Item, FilePosition) {
-        return (self.character_sequence, self.position);
+    fn consume(self) -> Self::Item {
+        return self.character_sequence;
     }
 }
 
@@ -87,8 +105,8 @@ impl PunctuationToken {
 impl Consume for PunctuationToken {
     type Item = Punctuation;
 
-    fn consume(self) -> (Self::Item, FilePosition) {
-        return (self.punctuation, self.position)
+    fn consume(self) -> Self::Item {
+        return self.punctuation;
     }
 }
 

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -1,22 +1,27 @@
 use std::collections::VecDeque;
 
-use crate::token::Token;
+use crate::token::{Token, TokenStruct};
 
 #[derive(Debug)]
 pub struct TokenStream {
-    tokens: VecDeque<Token>,
+    tokens: VecDeque<TokenStruct>,
 }
 
 impl TokenStream {
     pub fn new(tokens: Vec<Token>) -> TokenStream {
         TokenStream {
-            tokens: VecDeque::from(tokens),
+            tokens: VecDeque::from(
+                tokens
+                    .into_iter()
+                    .map(|token| TokenStruct::new(token))
+                    .collect::<Vec<TokenStruct>>(),
+            ),
         }
     }
 }
 
 impl Iterator for TokenStream {
-    type Item = Token;
+    type Item = TokenStruct;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.tokens.pop_front()
@@ -27,7 +32,7 @@ impl Iterator for TokenStream {
 mod tests {
     use crate::lexer::FilePosition;
     use crate::token::{
-        BuildToken, CharacterSequenceToken, NumberToken, StringLiteralToken, Token,
+        BuildToken, CharacterSequenceToken, NumberToken, StringLiteralToken, Token, TokenStruct,
     };
 
     use super::TokenStream;
@@ -35,10 +40,19 @@ mod tests {
     #[test]
     fn should_iterate_over_token_stream() {
         let expected_tokens = vec![
-            NumberToken::build_token(String::from("123"), FilePosition::new(1, 1)),
-            StringLiteralToken::build_token(String::from("foo"), FilePosition::new(1, 1)),
-            CharacterSequenceToken::build_token(String::from("abc"), FilePosition::new(1, 1)),
-            Token::EOF(FilePosition::new(1, 1)),
+            TokenStruct::new(NumberToken::build_token(
+                String::from("123"),
+                FilePosition::new(1, 1),
+            )),
+            TokenStruct::new(StringLiteralToken::build_token(
+                String::from("foo"),
+                FilePosition::new(1, 1),
+            )),
+            TokenStruct::new(CharacterSequenceToken::build_token(
+                String::from("abc"),
+                FilePosition::new(1, 1),
+            )),
+            TokenStruct::new(Token::EOF(FilePosition::new(1, 1))),
         ];
 
         let mut token_stream = TokenStream::new(vec![

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -6,6 +6,19 @@ use open_system_verilog::token::{
     BuildToken, CharacterSequenceToken, KeywordToken, OperatorToken, PunctuationToken,
     StringLiteralToken, NumberToken, Token,
 };
+use open_system_verilog::token_stream::TokenStream;
+
+fn assert_tokens_equal(tokens: TokenStream, expected_tokens: Vec<Token>) {
+    let token_iterator = tokens.enumerate();
+    let mut length = 0;
+
+    for (i, token) in token_iterator {
+        assert_eq!(token.kind(), &expected_tokens[i]);
+        length += 1;
+    }
+
+    assert_eq!(length, expected_tokens.len());
+}
 
 #[test]
 fn should_lex_svaunit_seq() {
@@ -97,9 +110,7 @@ fn should_lex_svaunit_seq() {
 
     let tokens = lexer.lex();
 
-    for (i, token) in tokens.enumerate() {
-        assert_eq!(token, expected_tokens[i]);
-    }
+    assert_tokens_equal(tokens, expected_tokens);
 }
 
 #[test]
@@ -1641,7 +1652,5 @@ fn should_lex_data_table() {
 
     let tokens = lexer.lex();
 
-    for (i, token) in tokens.enumerate() {
-        assert_eq!(token, expected_tokens[i]);
-    }
+    assert_tokens_equal(tokens, expected_tokens);
 }


### PR DESCRIPTION
## Summary
Introduces the token struct required by #49 in order to begin refactoring out common token logic to simplify the lexing code.