### PR TITLE
refactor: Improve parsing errors

### DIFF
--- a/src/syntax_node.rs
+++ b/src/syntax_node.rs
@@ -3,6 +3,8 @@ use crate::lexer::FilePosition;
 #[derive(Debug, PartialEq, Eq)]
 pub enum SyntaxNode {
     Identifier(IdentifierNode),
+    Error,
+    EOF,
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
Improve parse errors by extending the `std::error::Error` trait for parsing errors