### PR TITLE
feat: Add file path to parse errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 use open_system_verilog::compilation_unit::CompilationUnit;
 use open_system_verilog::config::Config;
 use open_system_verilog::lexer::Lexer;
+use open_system_verilog::parser::Parser;
 
 fn main() {
     let config = Config::build(env::args().peekable()).unwrap_or_else(|errors| {
@@ -32,7 +33,16 @@ fn evaluate(compilation_unit: &CompilationUnit) {
             eprintln!("{:?}", error);
             process::exit(1)
         });
+        let mut parser = Parser::new(file_path, tokens);
 
-        dbg!(tokens);
+        let ast = parser.parse().unwrap_or_else(|errors| {
+            for error in errors {
+                eprintln!("{error}");
+            }
+
+            process::exit(1);
+        });
+
+        dbg!(ast);
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -63,14 +63,20 @@ impl Token {
         character_sequence: String,
         file_position: FilePosition,
     ) -> Token {
-        Token::new(TokenKind::CharacterSequence(character_sequence), file_position)
+        Token::new(
+            TokenKind::CharacterSequence(character_sequence),
+            file_position,
+        )
     }
 
     pub fn build_escaped_identifier_token(
         escaped_identifier: String,
         file_position: FilePosition,
     ) -> Token {
-        Token::new(TokenKind::CharacterSequence(escaped_identifier), file_position)
+        Token::new(
+            TokenKind::CharacterSequence(escaped_identifier),
+            file_position,
+        )
     }
 
     pub fn build_operator_token(operator: Operator, file_position: FilePosition) -> Token {
@@ -81,10 +87,7 @@ impl Token {
         Token::new(TokenKind::Keyword(keyword), file_position)
     }
 
-    pub fn build_punctuation_token(
-        punctuation: Punctuation,
-        file_position: FilePosition,
-    ) -> Token {
+    pub fn build_punctuation_token(punctuation: Punctuation, file_position: FilePosition) -> Token {
         Token::new(TokenKind::Punctuation(punctuation), file_position)
     }
 
@@ -102,5 +105,13 @@ impl Token {
 
     pub fn consume(self) -> TokenKind {
         self.kind
+    }
+
+    pub fn consume_as_string(self) -> String {
+        match self.kind {
+            TokenKind::CharacterSequence(string) | TokenKind::Number(string) => string,
+            TokenKind::Punctuation(punctuation) => punctuation.to_string(),
+            _ => String::from(""),
+        }
     }
 }


### PR DESCRIPTION
## Summary
Parser now accepts a file path, allowing for error messages to be associated with the correct file.

Closes #16