### PR TITLE
Parse escaped identifiers

### DIFF
--- a/src/syntax_node.rs
+++ b/src/syntax_node.rs
@@ -1,23 +1,37 @@
 use crate::lexer::FilePosition;
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum SyntaxNode {
-    Identifier(IdentifierNode),
+pub enum SyntaxNodeKind {
+    Identifier(String),
     Error,
     EOF,
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct IdentifierNode {
-    identifier: String,
+#[derive(Debug, PartialEq)]
+pub struct SyntaxNode {
+    kind: SyntaxNodeKind,
     position: FilePosition,
 }
 
-impl IdentifierNode {
-    pub fn new(identifier: String, position: FilePosition) -> SyntaxNode {
-        SyntaxNode::Identifier(IdentifierNode {
-            identifier,
+impl SyntaxNode {
+    pub fn build_identifier(identifier: String, position: FilePosition) -> SyntaxNode {
+        SyntaxNode {
+            kind: SyntaxNodeKind::Identifier(identifier),
             position,
-        })
+        }
+    }
+
+    pub fn build_error() -> SyntaxNode {
+        SyntaxNode {
+            kind: SyntaxNodeKind::Error,
+            position: FilePosition::new(0, 0),
+        }
+    }
+
+    pub fn build_eof() -> SyntaxNode {
+        SyntaxNode {
+            kind: SyntaxNodeKind::EOF,
+            position: FilePosition::new(0, 0),
+        }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -74,7 +74,7 @@ impl Token {
         file_position: FilePosition,
     ) -> Token {
         Token::new(
-            TokenKind::CharacterSequence(escaped_identifier),
+            TokenKind::EscapedIdentifier(escaped_identifier),
             file_position,
         )
     }
@@ -109,7 +109,9 @@ impl Token {
 
     pub fn consume_as_string(self) -> String {
         match self.kind {
-            TokenKind::CharacterSequence(string) | TokenKind::Number(string) => string,
+            TokenKind::EscapedIdentifier(string)
+            | TokenKind::CharacterSequence(string)
+            | TokenKind::Number(string) => string,
             TokenKind::Punctuation(punctuation) => punctuation.to_string(),
             _ => String::from(""),
         }

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use crate::token::Token;
+use crate::{token::Token, lexer::FilePosition};
 
 #[derive(Debug)]
 pub struct TokenStream {
@@ -12,6 +12,10 @@ impl TokenStream {
         TokenStream {
             tokens: VecDeque::from(tokens),
         }
+    }
+
+    pub fn eof_position(&self) -> FilePosition {
+        self.tokens.back().map_or(FilePosition::new(1, 1), |token| token.position())
     }
 }
 


### PR DESCRIPTION
## Summary
Added support for parsing escaped identifiers and parsing identifiers themselves. Tested the happy paths, ensuring that it creates a node for an EscapedIdentifierToken

Closes #17