### PR TITLE
Parse basic identifiers

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -75,7 +75,91 @@ impl<'a> Parser<'a> {
             .map_or(self.eof_position, |token| token.position())
     }
 
+    fn parse_generate_block_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
     fn parse_genvar_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_array_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_block_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_bin_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_cell_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_checker_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_class_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_class_variable_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_clocking_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_config_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_const_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_constraint_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_covergroup_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_covergroup_variable_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_cover_point_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_cross_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_dynamic_array_variable_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_enum_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_formal_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_formal_port_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
+        self.parse_identifier()
+    }
+
+    fn parse_function_identifier(&mut self) -> Result<SyntaxNode, ParseError> {
         self.parse_identifier()
     }
 


### PR DESCRIPTION
## Summary
Parses some of the basic identifiers of the form

`{name} ::= identifier`

Closes 
#20
#22 
#23 
#24 
#25 
#26 
#27 
#28 
#29 
#30 
#31 
#32 
#33 
#34 
#35 
#36 
#37 
#38 
#39 
#40 